### PR TITLE
Move getRate logic to fxStateChildTunnel

### DIFF
--- a/contracts/interfaces/IFxStateChildTunnel.sol
+++ b/contracts/interfaces/IFxStateChildTunnel.sol
@@ -13,4 +13,6 @@ interface IFxStateChildTunnel {
 	function setFxRootTunnel(address _fxRootTunnel) external;
 
 	function getReserves() external view returns (uint256, uint256);
+
+	function getRate() external view returns (uint256);
 }

--- a/contracts/state-transfer/FxStateChildTunnel.sol
+++ b/contracts/state-transfer/FxStateChildTunnel.sol
@@ -47,4 +47,9 @@ contract FxStateChildTunnel is FxBaseChildTunnel, AccessControl {
 
 		return (maticX, MATIC);
 	}
+
+	function getRate() external view returns (uint256) {
+		(uint256 maticX, uint256 matic) = getReserves();
+		return (matic * 1 ether) / maticX;
+	}
 }

--- a/contracts/state-transfer/RateProvider.sol
+++ b/contracts/state-transfer/RateProvider.sol
@@ -19,9 +19,7 @@ contract RateProvider is IRateProvider, AccessControl {
 	}
 
 	function getRate() external view override returns (uint256) {
-		(uint256 maticX, uint256 matic) = IFxStateChildTunnel(fxChild)
-			.getReserves();
-		return (matic * 1 ether) / maticX;
+		return IFxStateChildTunnel(fxChild).getRate();
 	}
 
 	function setFxChild(address _fxChild)


### PR DESCRIPTION
This will make it easier for RateProvider to follow any logic updates.